### PR TITLE
更新年月日日期格式

### DIFF
--- a/rime.lua
+++ b/rime.lua
@@ -21,7 +21,7 @@ function date_translator(input, seg, env)
         local cand = Candidate("date", seg.start, seg._end, os.date("%Y.%m.%d"), "")
         cand.quality = 100
         yield(cand)
-        local cand = Candidate("date", seg.start, seg._end, os.date("%Y 年 %m 月 %d 日"), "")
+        local cand = Candidate("date", seg.start, seg._end, os.date("%Y 年 ")..tostring(tonumber(os.date("%m")))..os.date(" 月 %d 日"), "")
         cand.quality = 100
         yield(cand)
     end


### PR DESCRIPTION
原来的日期格式：
2023 年 04 月 25 日
更新后为：
2023 年 4 月 25 日

更符合中文阅读习惯